### PR TITLE
Add interactive football playbook builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# tornstrand.github.io
+# Football Playbook Creator
+
+This repository hosts a simple browser-based tool to sketch American football plays.
+Add players, name them, drag them into position and use the **Draw Route** button to
+sketch routes on a vertical field.
+
+Enter a label in the **Player name** box before adding a player or select an existing
+player and press **Rename Player** to update its label.
+
+Open `index.html` in a modern web browser to start designing plays.

--- a/index.html
+++ b/index.html
@@ -1,38 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Color Changer</title>
-<style>
-  body {
-    background-color: blue; /* Initial background color */
-    height: 100vh;
-    margin: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-  }
-  button {
-    padding: 10px 20px;
-    font-size: 16px;
-    cursor: pointer;
-  }
-</style>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>Football Playbook Creator</title>
+<link rel="stylesheet" href="style.css" />
 </head>
 <body>
-
-<button onclick="changeBackgroundColor()">Click</button>
-
-<script>
-  function changeBackgroundColor() {
-    const colors = ['red', 'green', 'yellow', 'purple', 'orange', 'pink', 'cyan', 'magenta'];
-    // Generate a random index based on the array length
-    const randomIndex = Math.floor(Math.random() * colors.length);
-    // Set the body's background color to a random color from the array
-    document.body.style.backgroundColor = colors[randomIndex];
-  }
-</script>
-
+<div id="toolbar">
+  <input id="playerName" placeholder="Player name" />
+  <button id="addPlayer">Add Player</button>
+  <button id="renamePlayer" disabled>Rename Player</button>
+  <button id="drawRoute" disabled>Draw Route</button>
+</div>
+<canvas id="field" width="480" height="960"></canvas>
+<script src="playbook.js"></script>
 </body>
 </html>

--- a/playbook.js
+++ b/playbook.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const canvas = document.getElementById('field');
+const ctx = canvas.getContext('2d');
+const addPlayerBtn = document.getElementById('addPlayer');
+const drawRouteBtn = document.getElementById('drawRoute');
+const playerNameInput = document.getElementById('playerName');
+const renamePlayerBtn = document.getElementById('renamePlayer');
+
+const players = [];
+let playerId = 1;
+let selectedPlayer = null;
+let draggingPlayer = null;
+let offsetX = 0;
+let offsetY = 0;
+let routeMode = false;
+
+function drawField() {
+  ctx.fillStyle = '#0a662e';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.strokeStyle = '#fff';
+  ctx.lineWidth = 2;
+  ctx.strokeRect(0, 0, canvas.width, canvas.height);
+
+  for (let i = 0; i <= 12; i++) {
+    const y = (canvas.height / 12) * i;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(canvas.width, y);
+    ctx.stroke();
+  }
+}
+
+function drawPlayers() {
+  players.forEach((p) => {
+    if (p.route.length) {
+      ctx.strokeStyle = 'yellow';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(p.x, p.y);
+      p.route.forEach((pt) => {
+        ctx.lineTo(pt.x, pt.y);
+      });
+      ctx.stroke();
+    }
+
+    ctx.beginPath();
+    ctx.fillStyle = p === selectedPlayer ? '#ff9800' : '#fff';
+    ctx.arc(p.x, p.y, 12, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = '#000';
+    ctx.stroke();
+
+    ctx.fillStyle = '#000';
+    ctx.font = '12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(p.label, p.x, p.y);
+  });
+}
+
+function render() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawField();
+  drawPlayers();
+}
+
+addPlayerBtn.addEventListener('click', () => {
+  const label = playerNameInput.value.trim() || `P${playerId}`;
+  players.push({ x: canvas.width / 2, y: canvas.height / 2, label, route: [] });
+  playerId++;
+  playerNameInput.value = '';
+  render();
+});
+
+canvas.addEventListener('mousedown', (e) => {
+  const { offsetX: mx, offsetY: my } = e;
+  for (const p of players) {
+    const dist = Math.hypot(p.x - mx, p.y - my);
+    if (dist < 12) {
+      if (!routeMode) {
+        selectedPlayer = p;
+        drawRouteBtn.disabled = false;
+        renamePlayerBtn.disabled = false;
+        playerNameInput.value = p.label;
+        draggingPlayer = p;
+        offsetX = mx - p.x;
+        offsetY = my - p.y;
+      }
+      render();
+      return;
+    }
+  }
+
+  if (routeMode && selectedPlayer) {
+    selectedPlayer.route.push({ x: mx, y: my });
+    render();
+  } else {
+    selectedPlayer = null;
+    drawRouteBtn.disabled = true;
+    renamePlayerBtn.disabled = true;
+    playerNameInput.value = '';
+    render();
+  }
+});
+
+canvas.addEventListener('mousemove', (e) => {
+  if (draggingPlayer && !routeMode) {
+    draggingPlayer.x = e.offsetX - offsetX;
+    draggingPlayer.y = e.offsetY - offsetY;
+    render();
+  }
+});
+
+canvas.addEventListener('mouseup', () => {
+  draggingPlayer = null;
+});
+
+drawRouteBtn.addEventListener('click', () => {
+  if (!selectedPlayer) return;
+  routeMode = !routeMode;
+  drawRouteBtn.textContent = routeMode ? 'Finish Route' : 'Draw Route';
+});
+
+renamePlayerBtn.addEventListener('click', () => {
+  if (!selectedPlayer) return;
+  const newLabel = playerNameInput.value.trim();
+  if (newLabel) {
+    selectedPlayer.label = newLabel;
+    render();
+  }
+});
+
+render();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,5 @@
+body { margin:0; display:flex; flex-direction:column; align-items:center; font-family:Arial, sans-serif; }
+#toolbar { margin:10px; }
+canvas { border:1px solid #fff; background:#0a662e; }
+button { margin-right:5px; }
+input { margin-right:5px; }


### PR DESCRIPTION
## Summary
- separate styles and script into their own files
- allow adding, naming, dragging, and drawing routes for players
- document how to sketch plays in the browser

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890622ac5cc832f940f175b2db8b390